### PR TITLE
Change transport to work with ElasticSearch 0.90 API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.couchbase</groupId>
   <artifactId>elasticsearch-transport-couchbase</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
-  
+  <version>1.0.2-SNAPSHOT</version>
+
     <properties>
-        <elasticsearch.version>0.20.2</elasticsearch.version>
+        <elasticsearch.version>0.90.0</elasticsearch.version>
     </properties>
-    
+
     <repositories>
 
         <repository>
@@ -17,7 +17,7 @@
         </repository>
 
     </repositories>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.elasticsearch</groupId>
@@ -37,7 +37,7 @@
             <version>1.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -82,5 +82,5 @@
             </plugin>
         </plugins>
     </build>
-  
+
 </project>

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
@@ -89,7 +89,7 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
         String index = getElasticSearchIndexNameFromDatabase(database);
         IndicesExistsRequestBuilder existsBuilder = client.admin().indices().prepareExists(index);
         IndicesExistsResponse response = existsBuilder.execute().actionGet();
-        if(response.exists()) {
+        if(response.isExists()) {
             return true;
         }
         return false;
@@ -181,9 +181,9 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
                 Iterator<MultiGetItemResponse> iterator = response.iterator();
                 while(iterator.hasNext()) {
                     MultiGetItemResponse item = iterator.next();
-                    if(item.response().exists()) {
-                        String itemId = item.id();
-                        Map<String, Object> source = item.response().sourceAsMap();
+                    if(item.getResponse().isExists()) {
+                        String itemId = item.getId();
+                        Map<String, Object> source = item.getResponse().getSourceAsMap();
                         if(source != null) {
                             Map<String, Object> meta = (Map<String, Object>)source.get("meta");
                             if(meta != null) {
@@ -311,13 +311,13 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
 
         BulkResponse response = bulkBuilder.execute().actionGet();
         if(response != null) {
-            for (BulkItemResponse bulkItemResponse : response.items()) {
+            for (BulkItemResponse bulkItemResponse : response.getItems()) {
                 Map<String, Object> itemResponse = new HashMap<String, Object>();
                 String itemId = bulkItemResponse.getId();
                 itemResponse.put("id", itemId);
-                if(bulkItemResponse.failed()) {
+                if(bulkItemResponse.isFailed()) {
                     itemResponse.put("error", "failed");
-                    itemResponse.put("reason", bulkItemResponse.failureMessage());
+                    itemResponse.put("reason", bulkItemResponse.getFailureMessage());
                 } else {
                     itemResponse.put("rev", revisions.get(itemId));
                 }
@@ -343,8 +343,8 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
 
     protected Map<String, Object> getDocumentElasticSearch(String index, String docId, String docType) {
         GetResponse response = client.prepareGet(index, docType, docId).execute().actionGet();
-        if(response != null && response.exists()) {
-            Map<String,Object> esDocument = response.sourceAsMap();
+        if(response != null && response.isExists()) {
+            Map<String,Object> esDocument = response.getSourceAsMap();
             return (Map<String, Object>)esDocument.get("doc");
         }
         return null;

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCouchbaseBehavior.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCouchbaseBehavior.java
@@ -94,7 +94,7 @@ public class ElasticSearchCouchbaseBehavior implements CouchbaseBehavior {
     public String getBucketUUID(String pool, String bucket) {
         IndicesExistsRequestBuilder existsBuilder = client.admin().indices().prepareExists(bucket);
         IndicesExistsResponse response = existsBuilder.execute().actionGet();
-        if(response.exists()) {
+        if(response.isExists()) {
             return "00000000000000000000000000000000";
         }
         return null;
@@ -114,9 +114,9 @@ public class ElasticSearchCouchbaseBehavior implements CouchbaseBehavior {
                 // FIXME there has to be a better way than
                 // parsing this string
                 // but so far I have not found it
-                if (nodeInfo.serviceAttributes() != null) {
+                if (nodeInfo.getServiceAttributes() != null) {
                     for (Map.Entry<String, String> nodeAttribute : nodeInfo
-                            .serviceAttributes().entrySet()) {
+                            .getServiceAttributes().entrySet()) {
                         if (nodeAttribute.getKey().equals(
                                 "couchbase_address")) {
                             int start = nodeAttribute


### PR DESCRIPTION
I wanted to use the transport plugin with Couchbase 2.0 and ElasticSearch 0.90 and I noticed that the ElasticSearch code changed some function names and the plugin no longer works. This patch (if you accept it) changes the plugin code to reflect the changes in ElasticSearch. I tested and replication works with the new changes. 

I also updated to plugin version, but I'm not sure that this is the version number you expect, so please tell me if it should be different. 
