### PR TITLE
ISSUE-23: Elasticsearch 0.90.7 compatibility.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
   <groupId>com.couchbase</groupId>
   <artifactId>elasticsearch-transport-couchbase</artifactId>
   <version>1.2.0</version>
-  
+
     <properties>
-        <elasticsearch.version>0.90.3</elasticsearch.version>
+        <elasticsearch.version>0.90.7</elasticsearch.version>
     </properties>
-    
+
     <repositories>
 
         <repository>


### PR DESCRIPTION
Bumped up the Client version to 0.90.7 to restore the ability to replicate to
Elasticsearch from Couchbase.

-=david=-
