### PR TITLE
added support for ignore deletes.

### DIFF
--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/CouchbaseCAPITransportImpl.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/CouchbaseCAPITransportImpl.java
@@ -16,6 +16,9 @@ package org.elasticsearch.transport.couchbase.capi;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -80,6 +83,8 @@ public class CouchbaseCAPITransportImpl extends AbstractLifecycleComponent<Couch
 
     private Map<String, String> documentTypeParentFields;
     private Map<String, String> documentTypeRoutingFields;
+    
+    private List<String> ignoreDeletes;
 
     @Inject
     public CouchbaseCAPITransportImpl(Settings settings, RestController restController, NetworkService networkService, IndicesService indicesService, MetaDataMappingService metaDataMappingService, Client client) {
@@ -131,6 +136,9 @@ public class CouchbaseCAPITransportImpl extends AbstractLifecycleComponent<Couch
             String routingField = documentTypeRoutingFields.get(key);
             logger.info("Using field {} as routing for type {}", routingField, key);
         }
+        
+        this.ignoreDeletes = new ArrayList<String>(Arrays.asList(settings.get("couchbase.ignore.delete","").split(":")));
+        logger.info("Couchbase transport will ignore delete operations for this buckets: {}", ignoreDeletes);        
     }
 
     @Override
@@ -157,7 +165,7 @@ public class CouchbaseCAPITransportImpl extends AbstractLifecycleComponent<Couch
         final InetAddress publishAddressHost = publishAddressHostX;
 
 
-        capiBehavior = new ElasticSearchCAPIBehavior(client, logger, typeSelector, checkpointDocumentType, dynamicTypePath, resolveConflicts.booleanValue(), maxConcurrentRequests, bulkIndexRetries, bulkIndexRetryWaitMs, bucketUUIDCache, documentTypeParentFields, documentTypeRoutingFields);
+        capiBehavior = new ElasticSearchCAPIBehavior(client, logger, typeSelector, checkpointDocumentType, dynamicTypePath, resolveConflicts.booleanValue(), maxConcurrentRequests, bulkIndexRetries, bulkIndexRetryWaitMs, bucketUUIDCache, documentTypeParentFields, documentTypeRoutingFields, ignoreDeletes);
         couchbaseBehavior = new ElasticSearchCouchbaseBehavior(client, logger, checkpointDocumentType, bucketUUIDCache);
 
         PortsRange portsRange = new PortsRange(port);


### PR DESCRIPTION
Motivation:
We would like to preserve docs in ElasticSearch while applying some eviction policy to docs in Couchbase. We need this behaviour in order to better utilize our resources: instead of holding the dataset in RAM in both CB and ES, we use ES as long term persistent while keeping CB for short term.
Example: docs are evicted from CB after 24Hours while ES keeps everything. We can use Curator to evict from ES after (for example) 90 days.

This fix causes ES to ignore delete operations + ignore TTL values.

How to use:
This feature is opt-in. In order to define specific (ignore deletes) indexes - the following line should be added in  elasticsearch.yml :

couchbase.ignore.delete: index1:index2...    (notice that indexes are colon separated