### PR TITLE
Select parent based on transformed value of field

### DIFF
--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
@@ -81,7 +81,7 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
     protected Cache<String, String> bucketUUIDCache;
 
     protected Map<String, String> documentTypeRoutingFields;
-    
+
 	protected List<String> ignoreDeletes;
 
     public ElasticSearchCAPIBehavior(Client client, ESLogger logger, KeyFilter keyFilter, TypeSelector typeSelector, ParentSelector parentSelector, String checkpointDocumentType, String dynamicTypePath, boolean resolveConflicts, boolean wrapCounters, long maxConcurrentRequests, long bulkIndexRetries, long bulkIndexRetryWaitMs, Cache<String, String> bucketUUIDCache, Map<String, String> documentTypeRoutingFields, List<String> ignoreDeletes, Boolean ignoreFailures) {
@@ -288,17 +288,17 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
 		//if set to true - all delete operations will be ignored
 		//ignoreDeletes contains a list of indexes to be ignored when delete events occur
 		//index list can be set in the elasticsearch.yml file using
-		//the key: couchbase.ignore.delete  the value is colon separated:  index1:index2:index3 
+		//the key: couchbase.ignore.delete  the value is colon separated:  index1:index2:index3
 		boolean ignoreDelete = ignoreDeletes != null && ignoreDeletes.contains(index);
         logger.trace("ignoreDelete = {}", ignoreDelete);
-        
+
         // keep a map of the id - rev for building the response
         Map<String,String> revisions = new HashMap<String, String>();
 
         // put requests into this map, not directly into the bulk request
         Map<String,IndexRequest> bulkIndexRequests = new HashMap<String,IndexRequest>();
         Map<String,DeleteRequest> bulkDeleteRequests = new HashMap<String,DeleteRequest>();
-        
+
         //used for "mock" results in case of ignore deletes or filtered out keys
         List<Object> mockResults = new ArrayList<Object>();
 
@@ -412,20 +412,20 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
                 routingField = documentTypeRoutingFields.get(type);
             }
             boolean deleted = meta.containsKey("deleted") ? (Boolean)meta.get("deleted") : false;
-            
-            if(deleted) {
-            	if (!ignoreDelete) {
-                	DeleteRequest deleteRequest = client.prepareDelete(index, type, id).request();
-                	bulkDeleteRequests.put(id, deleteRequest);
-            	}else{
-                	// For ignored deletes, we want to bypass from adding the delete request
-            		// as a hack - we add a "mock" response for each delete request as if ES returned
-            		// delete confirmation
-	                Map<String, Object> mockResponse = new HashMap<String, Object>();
-	                mockResponse.put("id", id);
-	                mockResponse.put("rev", rev);
-	                mockResults.add(mockResponse);
-            	}
+
+            if (deleted) {
+                if (!ignoreDelete) {
+                        DeleteRequest deleteRequest = client.prepareDelete(index, type, id).request();
+                        bulkDeleteRequests.put(id, deleteRequest);
+                } else {
+                        // For ignored deletes, we want to bypass from adding the delete request
+                        // as a hack - we add a "mock" response for each delete request as if ES returned
+                        // delete confirmation
+                        Map<String, Object> mockResponse = new HashMap<String, Object>();
+                        mockResponse.put("id", id);
+                        mockResponse.put("rev", rev);
+                        mockResults.add(mockResponse);
+                }
             } else {
                 IndexRequestBuilder indexBuilder = client.prepareIndex(index, type, id);
                 indexBuilder.setSource(toBeIndexed);
@@ -441,7 +441,8 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
                         logger.warn("Unable to determine parent value from parent field {} for doc id {}", parent, id);
                     }
                 }
-                if(routingField != null) {
+
+                if (routingField != null) {
                     Object routing = JSONMapPath(toBeIndexed, routingField);
                     if (routing != null && routing instanceof String) {
                         indexBuilder.setRouting((String)routing);
@@ -485,19 +486,19 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
                     throw new RuntimeException(e);
                 }
             }
-            
-            if(bulkBuilder.numberOfActions() > 0) {
-	            response = bulkBuilder.execute().actionGet();
+
+            if (bulkBuilder.numberOfActions() > 0) {
+                response = bulkBuilder.execute().actionGet();
             } else {
-            	isEmptyBulk = true;
+                isEmptyBulk = true;
             }
-            
-            if(response != null) {
+
+            if (response != null) {
                 for (BulkItemResponse bulkItemResponse : response.getItems()) {
                     String itemId = bulkItemResponse.getId();
                     String itemRev = revisions.get(itemId);
 
-                    if(!bulkItemResponse.isFailed()) {
+                    if (!bulkItemResponse.isFailed()) {
                         Map<String, Object> itemResponse = new HashMap<String, Object>();
                         itemResponse.put("id", itemId);
                         itemResponse.put("rev", itemRev);
@@ -510,12 +511,12 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
                         Failure failure = bulkItemResponse.getFailure();
 
                         // If the error is fatal, don't retry the request.
-                        if(failureMessageAppearsFatal(failure.getMessage())) {
+                        if (failureMessageAppearsFatal(failure.getMessage())) {
                             logger.error("error indexing document id: " + itemId + " exception: " + failure.getMessage());
 
                             // If ignore failures mode is on, store a mock result object for the failed
                             // operation, which will be returned to Couchbase.
-                            if(ignoreFailures) {
+                            if (ignoreFailures) {
                                 Map<String, Object> mockResult = new HashMap<String, Object>();
                                 mockResult.put("id", itemId);
                                 mockResult.put("rev", itemRev);
@@ -523,9 +524,9 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
 
                                 bulkIndexRequests.remove(itemId);
                                 bulkDeleteRequests.remove(itemId);
-                            }
-                            else
+                            } else {
                                 throw new RuntimeException("indexing error " + failure.getMessage());
+                            }
                         }
                     }
                 }
@@ -533,11 +534,11 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
             retriesLeft--;
         } while(!isEmptyBulk && (response != null) && (response.hasFailures()) && (retriesLeft > 0));
 
-        if(!isEmptyBulk && response == null) {
+        if (!isEmptyBulk && response == null) {
             throw new RuntimeException("indexing error, bulk response was null");
         }
 
-        if(retriesLeft == 0 && !ignoreFailures) {
+        if (retriesLeft == 0 && !ignoreFailures) {
             throw new RuntimeException("indexing error, bulk failed after all retries");
         }
 
@@ -546,12 +547,12 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
         long end = System.currentTimeMillis();
         meanBulkDocsRequests.inc(end - start);
         activeBulkDocsRequests.dec();
-        
+
         // Before we return, in case of ignore delete or filtered keys
         // we want to add the "mock" confirmations for the ignored operations
         // in order to satisfy the XDCR mechanism
         if(mockResults != null && mockResults.size() > 0){
-        	result.addAll(mockResults);
+            result.addAll(mockResults);
         }
         return result;
     }

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
@@ -368,10 +368,19 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
                                 logger.error("Unable to parse decoded base64 data as either JSON or long, indexing stub for id: {}", meta.get("id"));
                                 logger.error("Body was: {} Parse error was: {} Long parse error was: {}", new String(decodedData), e, e2);
                             }
-                        }
-                        else {
-                            logger.error("Unable to parse decoded base64 data as JSON, indexing stub for id: {}", meta.get("id"));
-                            logger.error("Body was: {} Parse error was: {}", new String(decodedData), e);
+                        } else {
+                            logger.trace(
+                                "Trying to wrap decoded base64 data in an Object as 'content' field, id: {}",
+                                meta.get("id"));
+                            try {
+                                decodedData = "{\"content\":"+decodedData+"}";
+                                json = (Map<String, Object>) mapper.readValue(decodedData, Map.class);
+                            } catch (Exception e3) {
+                                logger.error(
+                                    "Unable to parse decoded base64 data as JSON, indexing stub for id: {}",
+                                    meta.get("id"));
+                                logger.error("Body was: {} Parse error was: {}", new String(decodedData), e);
+                            }
                         }
                     }
                 } catch (IOException e) {

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/TransformedFieldParentSelector.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/TransformedFieldParentSelector.java
@@ -1,0 +1,102 @@
+package org.elasticsearch.transport.couchbase.capi;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Select parent based on transformed field value. Usage:
+ *
+ * <pre>
+ * {@code
+ * couchbase.parentSelector: org.elasticsearch.transport.couchbase.capi.TransformedFieldParentSelector
+ * couchbase.documentTypeParentFields.childType: doc.parentIdField/(.+)/parentType:$1
+ * }
+ * </pre>
+ *
+ * @author tungd on 4/26/15.
+ */
+
+public class TransformedFieldParentSelector implements ParentSelector {
+    protected ESLogger logger = Loggers.getLogger(getClass());
+
+    public static final String FIELD_DELIMITER = "/";
+
+    private Map<String, FieldTransform> documentTypeParentFields;
+
+    private class FieldTransform {
+        public String field;
+        public Pattern match;
+        public String replace;
+
+        public FieldTransform(String field, String match, String replace) {
+            this.field = field;
+            this.match = Pattern.compile(match);
+            this.replace = replace;
+        }
+
+        @Override
+        public String toString() {
+            return match + "/" + replace;
+        }
+
+        public Object transform(Object input) {
+            if (!(input instanceof String)) {
+                return input;
+            }
+
+            Matcher matcher = match.matcher((String)input);
+            if (!matcher.matches()) {
+                return input;
+            }
+
+            return matcher.replaceFirst(replace);
+        }
+    }
+
+    @Override
+    public void configure(Settings settings) {
+        Map<String, String> config = settings.getByPrefix(
+                "couchbase.documentTypeParentFields.").getAsMap();
+
+        documentTypeParentFields = new HashMap<String, FieldTransform>();
+
+        for (String key : config.keySet()) {
+            String[] parts = config.get(key).split(FIELD_DELIMITER);
+
+            if (parts.length != 3) {
+                logger.error("Invalid transformation defined for type {}: {}", key, config.get(key));
+                continue;
+            }
+
+            String field = parts[0];
+            FieldTransform transformer = new FieldTransform(field, parts[1], parts[2]);
+            documentTypeParentFields.put(key, transformer);
+
+            logger.info(
+                    "Using field {} as parent for type {}, with transformation: {}",
+                    field, key, transformer);
+        }
+    }
+
+    @Override
+    public Object getParent(Map<String, Object> doc, String docId, String type) {
+        FieldTransform transform = null;
+
+        if (documentTypeParentFields != null
+                && documentTypeParentFields.containsKey(type)) {
+            transform = documentTypeParentFields.get(type);
+        }
+        if (transform == null) {
+            return null;
+        }
+
+        return transform.transform(ElasticSearchCAPIBehavior.JSONMapPath(doc,
+                transform.field));
+    }
+}


### PR DESCRIPTION
Hi,

I've been experimenting with this plugin last week. It worked pretty great, and the upcoming features in 2.1.0 are very nice, especially the new type selectors. However there's an issue regarding parent selector. The recommended practice is to have Couchbase document id in the form "type_id", or "type:id", I did that already, but the field in my child document only have the id of the parent document without type prefix.

I tried to implement an alternate parent selector, based on simple Regular Expression match/replace.
Hope this can be included in the next version.

Sample usage if I have a `childType` type with `parentIdField` containing the id of `parentType`:

```
couchbase.parentSelector: org.elasticsearch.transport.couchbase.capi.TransformedFieldParentSelector
couchbase.documentTypeParentFields.childType: doc.parentIdField/(.+)/parentType:$1
```

Thanks.
