### PR TITLE
add id selector for typeSelector

### DIFF
--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/DefaultTypeSelector.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/DefaultTypeSelector.java
@@ -23,5 +23,10 @@ public class DefaultTypeSelector implements TypeSelector {
         }
         return this.defaultDocumentType;
     }
+    
+    @Override
+    public String getId(String index, String docId) {
+    	return docId;
+    }
 
 }

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/DelimiterTypeSelector.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/DelimiterTypeSelector.java
@@ -12,7 +12,7 @@ public class DelimiterTypeSelector extends DefaultTypeSelector {
     public static final String DEFAULT_DOCUMENT_TYPE_DELIMITER = ":";
     private String documentTypeDelimiter;
     protected ESLogger logger = Loggers.getLogger(getClass());
-
+    private Boolean DocumentTypeId;
     public DelimiterTypeSelector () {
         this.documentTypeDelimiter = DEFAULT_DOCUMENT_TYPE_DELIMITER; // Sanity
     }
@@ -23,6 +23,8 @@ public class DelimiterTypeSelector extends DefaultTypeSelector {
 
         this.documentTypeDelimiter = settings.get("couchbase.typeSelector.documentTypeDelimiter", DelimiterTypeSelector.DEFAULT_DOCUMENT_TYPE_DELIMITER);
         logger.info("Couchbase transport is using type selector with delimiter: {}", documentTypeDelimiter);
+        this.DocumentTypeId = settings.getAsBoolean("couchbase.typeSelector.documentTypeId", false);
+        logger.info("Couchbase transport is using type index retrieve: {}", DocumentTypeId);
     }
 
     @Override
@@ -31,5 +33,16 @@ public class DelimiterTypeSelector extends DefaultTypeSelector {
         final int pos = docId.indexOf(documentTypeDelimiter);
 
         return pos > 0 ? docId.substring(0, pos) : super.getType(index, docId);
+    }
+    
+    @Override
+    public String getId(final String index, final String docId)
+    {
+    	if (DocumentTypeId) {
+    		final int pos = docId.indexOf(documentTypeDelimiter);		 
+    		return pos > 0 ? docId.substring(pos + 1, docId.length()) : super.getId(index, docId);
+    	}else{
+    		return docId;
+    	}
     }
 }

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/GroupRegexTypeSelector.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/GroupRegexTypeSelector.java
@@ -19,7 +19,9 @@ public class GroupRegexTypeSelector extends DefaultTypeSelector {
     protected ESLogger logger = Loggers.getLogger(getClass());
 
     private static final String TYPE = "type";
+    private static final String ID = "id";
     private Pattern documentTypesRegex;
+    private Pattern documentIdsRegex;
 
     @Override
     public void configure(Settings settings) {
@@ -31,6 +33,14 @@ public class GroupRegexTypeSelector extends DefaultTypeSelector {
             throw new RuntimeException("No configuration found for couchbase.typeSelector.documentTypesRegex, please set types regex");
         }
         documentTypesRegex = Pattern.compile(documentTypesPattern);
+        
+        String documentIdsPattern = settings.get("couchbase.typeSelector.documentIdsRegex");
+        if (null == documentIdsPattern) {
+            logger.error("No configuration found for couchbase.typeSelector.documentIdsRegex, please set types regex");
+            documentIdsRegex = null;
+        }else{
+        	documentIdsRegex = Pattern.compile(documentTypesPattern);
+        }
     }
 
     @Override
@@ -42,5 +52,20 @@ public class GroupRegexTypeSelector extends DefaultTypeSelector {
 
         logger.warn("Document Id {} does not match type group regex - use default document type", docId);
         return super.getType(index, docId);
+    }
+    
+    @Override
+    public String getId(final String index, final String docId)
+    {
+    	if (null == documentIdsRegex) {
+    		return docId;
+    	}
+    	Matcher matcher = documentIdsRegex.matcher(docId);
+        if (matcher.matches()) {
+            return matcher.group(ID);
+        }
+
+        logger.warn("Document Id {} does not match type group regex - use default document type", docId);
+        return super.getId(index, docId);
     }
 }

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/TypeSelector.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/TypeSelector.java
@@ -5,4 +5,5 @@ import org.elasticsearch.common.settings.Settings;
 public interface TypeSelector {
     void configure(Settings settings);
     String getType(String index, String docId);
+    String getId(String index, String docId);
 }


### PR DESCRIPTION
When you change the typeSelector to a specific typeSelector like DelimiterTypeSelector.

The document type is correctly extracted from the id, but we want to remove the document type from the id stored to ES. 
We add for each TypeSelector, a specific configuration parameter to be able to change the id of the document.

For exemple for DelimeterTypeSelector you add  
couchbase.typeSelector.documentTypeId: true is the configuration a document stored to couchbase like
type:id will be stored to ES in type/id instead of type:type:id
