### PR TITLE
Fix exclude keyFilter with _sync issue

### DIFF
--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
@@ -336,7 +336,7 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
             // Filter documents by ID.
             // Delete operations are always allowed through to ES, to make sure newly configured
             // filters don't cause documents to stay in ES forever.
-            if(!keyFilter.shouldAllow(index, id) && !meta.containsKey("deleted")) {
+            if(!keyFilter.shouldAllow(index, id)) {
                 // Document ID matches one of the filters, not passing it to on to ES.
                 // Store a mock response, which will be added to the responses sent back
                 // to Couchbase, to satisfy the XDCR mechanism


### PR DESCRIPTION
If meta like this:
{id=_sync:rev:DOC:1:34:1-1ff55cbd2b0a24dd83101b3f042d1040,
rev=2-000003306a06ea730000000000000000, att_reason=invalid_json,
expiration=0, flags=0, deleted=true}
The deletion in ES will throw the error:
org.elasticsearch.indices.InvalidTypeNameException: mapping type name
[_sync] can't start with '_'

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/elasticsearch-transport-couchbase/97)

<!-- Reviewable:end -->
