### PR TITLE
Add 'couchbase.pipeline' config for specifying ingestion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Configuration for the plugin is specified as part of the Elasticsearch config fi
 - **couchbase.wrapCounters** - Enabling this flag will cause the plugin to wrap integer values from Couchbase, which are not valid JSON documents, in a simple document before indexing them in Elasticsearch. The resulting document is in the format `{ "value" : <value> }` and is stored under the ID of the original value from Couchbase.
 - **couchbase.ignoreDotIndexes** - Enabled by default (`true`). Causes the plugin to completely ignore indexes/aliases whose name starts with ".", such as ".kibana", ".marvel", etc.
 - **couchbase.includeIndexes** - Specifying one or more index/alias names (as a comma delimited string) here will cause the plugin to ignore the existence of all other indexes. For example, if you have only a few indexes replicated from Couchbase, there's no reason to store checkpoint metadata in all other indexes. Note that this setting takes precedence over ignoreDotIndexes, so if you whitelist an index or alias that starts with a dot, the plugin will use it.
+- **couchbase.pipeline** - Specify a pipeline to use when ingesting (Elasticsearch 5+ only), no default. **CAVEAT:** The pipeline processors must not change the index name or document metadata.
 
 ### Mapping Couchbase documents to Elasticsearch types ###
 

--- a/src/main/java/org/elasticsearch/plugin/transport/couchbase/CouchbaseCAPITransportPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/transport/couchbase/CouchbaseCAPITransportPlugin.java
@@ -85,6 +85,7 @@ public class CouchbaseCAPITransportPlugin extends Plugin {
                 CouchbaseCAPIService.Config.DOCUMENT_TYPE_PARENT_FORMAT,
                 CouchbaseCAPIService.Config.KEY_FILTER,
                 CouchbaseCAPIService.Config.KEY_FILTER_TYPE,
-                CouchbaseCAPIService.Config.KEY_FILTER_REGEX_LIST);
+                CouchbaseCAPIService.Config.KEY_FILTER_REGEX_LIST,
+                CouchbaseCAPIService.Config.PIPELINE);
     }
 }

--- a/src/main/java/org/elasticsearch/transport/couchbase/CouchbaseCAPIService.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/CouchbaseCAPIService.java
@@ -57,6 +57,9 @@ public interface CouchbaseCAPIService {
         public static final Setting<Settings> DOCUMENT_TYPE_PARENT_REGEX = Setting.groupSetting("couchbase.parentSelector.documentTypesParentRegex.", Setting.Property.NodeScope);
         public static final Setting<Settings> DOCUMENT_TYPE_PARENT_FORMAT = Setting.groupSetting("couchbase.parentSelector.documentTypesParentFormat.", Setting.Property.NodeScope);
 
+        // Ingestion
+        public static final Setting<String> PIPELINE = Setting.simpleString("couchbase.pipeline", Property.NodeScope);
+
         // Filtering
         public static final Setting<String> KEY_FILTER = new Setting<>("couchbase.keyFilter", s -> "org.elasticsearch.transport.couchbase.capi.DefaultKeyFilter", Function.identity(), Property.NodeScope);
         public static final Setting<String> KEY_FILTER_TYPE = new Setting<>("couchbase.keyFilter.type", s -> "exclude", Function.identity(), Property.NodeScope);

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
@@ -429,6 +429,7 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
                 } else {
                     IndexRequestBuilder indexBuilder = client.prepareIndex(index, type, id);
                     indexBuilder.setSource(toBeIndexed);
+                    indexBuilder.setPipeline(pluginSettings.getPipeline());
                     if (!ignoreDelete && ttl > 0) {
                         indexBuilder.setTTL(ttl);
                     }

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/PluginSettings.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/PluginSettings.java
@@ -1,5 +1,6 @@
 package org.elasticsearch.transport.couchbase.capi;
 
+import com.google.common.base.Strings;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.settings.NoClassSettingsException;
 import org.elasticsearch.common.settings.Settings;
@@ -37,6 +38,8 @@ public class PluginSettings {
 
     private int port;
 
+    private String pipeline;
+
     public PluginSettings(Settings settings) {
         this.setCheckpointDocumentType(CouchbaseCAPIService.Config.CHECKPOINT_DOCUMENT_TYPE.get(settings));
         this.setResolveConflicts(CouchbaseCAPIService.Config.RESOLVE_CONFLICTS.get(settings));
@@ -52,6 +55,7 @@ public class PluginSettings {
         this.setIncludeIndexes(CouchbaseCAPIService.Config.INCLUDE_INDEXES.get(settings));
         this.getIncludeIndexes().removeAll(Arrays.asList("", null));
         this.setPort(CouchbaseCAPIService.Config.PORT.get(settings));
+        this.setPipeline(Strings.emptyToNull(CouchbaseCAPIService.Config.PIPELINE.get(settings)));
 
         TypeSelector typeSelector;
         Class<? extends TypeSelector> typeSelectorClass = this.getAsClass(CouchbaseCAPIService.Config.TYPE_SELECTOR.get(settings), DefaultTypeSelector.class);
@@ -117,6 +121,7 @@ public class PluginSettings {
                 ", ignoreDeletes=" + ignoreDeletes +
                 ", includeIndexes=" + includeIndexes +
                 ", port=" + port +
+                ", pipeline='" + pipeline + '\'' +
                 '}';
     }
 
@@ -238,5 +243,13 @@ public class PluginSettings {
 
     public void setPort(int port) {
         this.port = port;
+    }
+
+    public String getPipeline() {
+        return pipeline;
+    }
+
+    public void setPipeline(String pipeline) {
+        this.pipeline = pipeline;
     }
 }


### PR DESCRIPTION
Won't solve the rolling index problem, but may be useful for developers who want to massage the data before indexing.