### PR TITLE
Add Gradle dependency software.amazon.awssdk:sts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ dependencies {
   implementation("software.amazon.awssdk:apache-client")
   implementation("software.amazon.awssdk:regions")
   implementation("software.amazon.awssdk:auth")
+  implementation("software.amazon.awssdk:sts")
 
   implementation platform('com.fasterxml.jackson:jackson-bom:2.18.2')
   implementation 'com.fasterxml.jackson.core:jackson-databind'


### PR DESCRIPTION
The AWS STS dependency is required to support the IRSA method of authentication when running in Kubernetes

Authentication with IRSA is the recommended way to access AWS resources

Example error from the connector if this package is not installed when attempting to access resources via an AWS service account: 
> WARN s.a.a.a.c.i.WebIdentityCredentialsUtils - To use web identity tokens, the 'sts' service module must be on the class path. Exception in thread "main" software.amazon.awssdk.core.exception.SdkClientException: Unable to load credentials from any of the providers in the chain AwsCredentialsProviderChain

When we deployed the connector to our environment with this added dependency the connector started up healthy and functioned as expected

Reference docs:
"Use IRSA with the AWS SDK" https://docs.aws.amazon.com/en_ca/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html  
"IRSA Overview" https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html  
