### PR TITLE
Update all awssdk dependencies for IRSA compatability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   implementation("org.opensearch.client:opensearch-rest-client:2.19.1")
   implementation('org.apache.httpcomponents.client5:httpclient5:5.4.2')
 
-  implementation(platform('software.amazon.awssdk:bom:2.20.26'))
+  implementation(platform('software.amazon.awssdk:bom:2.31.2'))
   implementation("software.amazon.awssdk:sdk-core")
   implementation("software.amazon.awssdk:apache-client")
   implementation("software.amazon.awssdk:regions")

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ dependencies {
   implementation("software.amazon.awssdk:apache-client")
   implementation("software.amazon.awssdk:regions")
   implementation("software.amazon.awssdk:auth")
+  implementation("software.amazon.awssdk:sts")
 
   implementation platform('com.fasterxml.jackson:jackson-bom:2.18.2')
   implementation 'com.fasterxml.jackson.core:jackson-databind'


### PR DESCRIPTION
In the latest version of the connector when making requests of the service via AWS IRSA authentication in Kubernetes this error is thrown:

```
Exception in thread "main" java.lang.NoClassDefFoundError: software/amazon/awssdk/identity/spi/Identity
	at com.couchbase.connector.elasticsearch.OpenSearchHelper.newAwsTransport(OpenSearchHelper.java:193)
	at com.couchbase.connector.elasticsearch.OpenSearchHelper.newAwsOpenSearchSinkOps(OpenSearchHelper.java:169)
	at com.couchbase.connector.elasticsearch.sink.SinkOps.create(SinkOps.java:52)
	at com.couchbase.connector.elasticsearch.ElasticsearchConnector.run(ElasticsearchConnector.java:236)
	at com.couchbase.connector.elasticsearch.ElasticsearchConnector$ConnectorRunner.run(ElasticsearchConnector.java:204)
	at com.couchbase.connector.elasticsearch.ElasticsearchConnector.run(ElasticsearchConnector.java:216)
	at com.couchbase.connector.elasticsearch.ElasticsearchConnector.main(ElasticsearchConnector.java:169)
Caused by: java.lang.ClassNotFoundException: software.amazon.awssdk.identity.spi.Identity
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
```

In the previous commit https://github.com/couchbase/couchbase-elasticsearch-connector/commit/3c52e2f75c50e4f315ded45fb9204ad6426aec28 to add support for IRSA this error didn't happen so something else changed in between that time to explain why it's behaving differently now

However, If all the awssdk dependencies are upgraded to the latest version 2.31.2 then the connector works fine again